### PR TITLE
Update wine version in Lutris

### DIFF
--- a/lutris/streamerbot.yaml
+++ b/lutris/streamerbot.yaml
@@ -18,7 +18,7 @@ script:
         filename: streamerbot.zip
 
   wine:
-    version: lutris-7.1-x86_64
+    version: wine-ge-8-26-x86_64
 
   installer:
     - extract:


### PR DESCRIPTION
After a recent lutris update, older wine versions have been removed. This changes the minimum version of wine to wine-ge-8-26-x86_64 as to maintain compatibility.